### PR TITLE
Addition to metrics

### DIFF
--- a/torchsample/metrics.py
+++ b/torchsample/metrics.py
@@ -40,7 +40,7 @@ class CategoricalAccuracy(Metric):
         self.total_count = 0
         self.accuracy = 0
 
-        self._name = 'acc_metric'
+        self._name = 'acc_metric:top_'+str(top_k)
 
     def reset(self):
         self.correct_count = 0


### PR DESCRIPTION
This is a quick fix. There's a better (more generic) way of differentiating metrics by providing a name as one of the constructor variables but that can be done later.